### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Quil examples
 
 Examples of Quil sketches.
 
-Check `src/quil_sketches` folder and it's subfolders. Each `.clj` file is a separate sketch. Some of them shows particular Quil feature and some of them are simply beatiful animations. You can start with running them one by one and studying their sources.
+Check `src/quil_sketches` folder and it's subfolders. Each `.clj` file is a separate sketch. Some of them shows particular Quil feature and some of them are simply beautiful animations. You can start with running them one by one and studying their sources.
 
 ### How to run examples
 


### PR DESCRIPTION
@quil, I've corrected a typographical error in the documentation of the [quil-examples](https://github.com/quil/quil-examples) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.