### PR TITLE
Quil 3 migration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject quil-sketches "0.1.0-SNAPSHOT"
   :description "Examples of using Quil library"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [quil "2.5.0"]])
+                 [quil "3.0.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,6 @@
 (defproject quil-sketches "0.1.0-SNAPSHOT"
   :description "Examples of using Quil library"
+  :url "https://github.com/quil/quil-examples"
+
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [quil "3.0.0"]])

--- a/src/quil_sketches/automata.clj
+++ b/src/quil_sketches/automata.clj
@@ -1,53 +1,62 @@
 (ns quil-sketches.automata
   "This module visualizes elementary cellular automata. It's primarily intended
-   to show off the fun aspects of functional programming and lazy-sequences in clojure to those who are coming from an OO background.
+  to show off the fun aspects of functional programming and lazy-sequences in
+  clojure to those who are coming from an OO background.
 
    If you're interested in how elementary cellular automata work, see:
-   http://mathworld.wolfram.com/ElementaryCellularAutomaton.html and
-   http://en.wikipedia.org/wiki/Elementary_cellular_automaton
+  http://mathworld.wolfram.com/ElementaryCellularAutomaton.html and
+  http://en.wikipedia.org/wiki/Elementary_cellular_automaton
 
-   Also, I highly recommend reading this source file bottom to top in order to understand it best.
+   Also, I highly recommend reading this source file bottom to top in order to
+  understand it best.
 
-   In particular, the code here makes heavy use of lazy-sequences, both directly through
-   `lazy-seq` and also through functions like map, for, partition, and other functions that
-   in clojure return lazy sequences. In some cases, we force lazy-evaluation for side-effects with
-   (dorun).
+   In particular, the code here makes heavy use of lazy-sequences, both directly
+  through `lazy-seq` and also through functions like map, for, partition, and
+  other functions that in clojure return lazy sequences. In some cases, we force
+  lazy-evaluation for side-effects with (dorun).
 
-   Since the visualization is of a stream of states for the automata, lazy-sequences are a very apt model. 
-   We can define a sequence of all future results, and simply iterate our way toward where we'd like to be.
-   At a high level this library revolves around a single lazy seq that represents all future states.
+   Since the visualization is of a stream of states for the automata,
+  lazy-sequences are a very apt model. We can define a sequence of all future
+  results, and simply iterate our way toward where we'd like to be. At a high
+  level this library revolves around a single lazy seq that represents all
+  future states.
 
-   The rendering model here is quite simple, we use pure clojure to fill a 2D array of 1s and 0s that contains
-   the current on-screen state. This 2D buffer is, itself, a partition (e.g. slice) of the lazy sequence of all
-   future states. See the run-rule function for more detail.
+   The rendering model here is quite simple, we use pure clojure to fill a 2D
+  array of 1s and 0s that contains the current on-screen state. This 2D buffer
+  is, itself, a partition (e.g. slice) of the lazy sequence of all future
+  states. See the run-rule function for more detail.
    
-   The core functions behind the laziness are (run-rule) which sets up the initial state and UI, 
-   (simulation), which returns a lazy sequence of results,
-   and (simulate) which does the legwork of applying the automaton's rules.
+   The core functions behind the laziness are (run-rule) which sets up the
+  initial state and UI, (simulation), which returns a lazy sequence of results,
+  and (simulate) which does the legwork of applying the automaton's rules.
 
-   There are other functional aspects here at play. The (rule) function for instance, is a higher-order function,
-   meaning that it returns a brand new function. The function it returns implements a given rule, matching the patterns
-   of the rule to outputs"
+   There are other functional aspects here at play. The (rule) function for
+  instance, is a higher-order function, meaning that it returns a brand new
+  function. The function it returns implements a given rule, matching the
+  patterns of the rule to outputs"
   (:gen-class)
   (:require [quil.core :as qc]
-	    [clojure.pprint :refer :all])
+    [clojure.pprint :refer :all])
   (:import java.lang.Math))
 
 ;; Colors for each cell
 (def live-color [242 233 99])
 (def dead-color [64 37 27])
 
-;; Elementary automata use a clever trick to allow us to describe an entire rule with only a few numbers.
-;; Since the automata are essentially pattern matchers, describing what a trio of living / dead cells evaluate to
-;; we can effeciently encode their behaviour as a sequence of 1s and 0s. A good visualization of this can be found
-;; here, at wolfram math world: http://mathworld.wolfram.com/ElementaryCellularAutomaton.html
+;; Elementary automata use a clever trick to allow us to describe an entire rule
+;; with only a few numbers. Since the automata are essentially pattern matchers,
+;; describing what a trio of living / dead cells evaluate to we can effeciently
+;; encode their behaviour as a sequence of 1s and 0s. A good visualization of
+;; this can be found here, at wolfram math world:
+;; http://mathworld.wolfram.com/ElementaryCellularAutomaton.html
 (defn int->bdigits
   "Gets the binary digits that comprise an integer as a seq of ints."
   [number]
   (for [c (Integer/toBinaryString number)] (Integer/valueOf (str c))))
 
 (defn zero-pad
-  "Forward pads a seq with 0s to match a given length. Used for making sure int->bdigits hits byte boundaries"
+  "Forward pads a seq with 0s to match a given length. Used for making sure
+  int->bdigits hits byte boundaries"
   [x len]
   (let [shortage (- len (count x))]
     (if (< shortage 1)
@@ -55,9 +64,9 @@
       (concat (repeat shortage 0) x))))
 
 (def input-patterns
-  "The list of possible input sequences for elementary cellular automata, which are easily generated
-   by counting down from 8 in binary, and making sure we have at least three digits.
-   This should produce a list like: ((111 110 ...))"
+  "The list of possible input sequences for elementary cellular automata, which
+  are easily generated by counting down from 8 in binary, and making sure we
+  have at least three digits. This should produce a list like: ((111 110 ...))"
   (map #(zero-pad (int->bdigits %1) 3) (range 8)))
 
 (defn rule-mappings
@@ -65,30 +74,32 @@
    {(0 1 1) 1
     ...}"
   [number]
-  ;; Zipmap combines two sequences into a map, much like a real-life zipper!
-  ;; The key here is that the magic rule numbers are not numbers at all
-  ;; but a sequence rather (their individual binary digits) that get mapped
-  ;; onto the list of possible inputs described in input-patterns.
-  ;; The heart of the generic solution here is really just checking
-  ;; equality of a sequence, which we can do via a lookup in the hashmap
-  ;; this generates
+  ;; Zipmap combines two sequences into a map, much like a real-life zipper! The
+  ;; key here is that the magic rule numbers are not numbers at all but a
+  ;; sequence rather (their individual binary digits) that get mapped onto the
+  ;; list of possible inputs described in input-patterns. The heart of the
+  ;; generic solution here is really just checking equality of a sequence, which
+  ;; we can do via a lookup in the hashmap this generates
   (zipmap input-patterns
-          (reverse (zero-pad (int->bdigits number) 8))))
+    (reverse (zero-pad (int->bdigits number) 8))))
 
 (defn rule
-  "Returns a function that will process a triad of input values according to a given rule #.
-   Since rules are simple lookup tables, this maps to nothing more than a get really.
-   We use a function here only to be able to close over the rule-mappings and only evaluate those once."
+  "Returns a function that will process a triad of input values according to a
+  given rule #. Since rules are simple lookup tables, this maps to nothing more
+  than a get really. We use a function here only to be able to close over the
+  rule-mappings and only evaluate those once."
   [number]
-  ;; Applying a rule is really simple, since we've reduced the problem to pattern matching, and
-  ;; clojrue can match lists well (e.g. (= [1 2 3] [1 2 3]) => true even though they're separate
-  ;; objects), can simply see which pattern the 3 given values match with a map lookup via get.
+  ;; Applying a rule is really simple, since we've reduced the problem to
+  ;; pattern matching, and clojrue can match lists well (e.g. (= [1 2 3] [1 2
+  ;; 3]) => true even though they're separate objects), can simply see which
+  ;; pattern the 3 given values match with a map lookup via get.
   (let [mappings (rule-mappings number)]
     (fn [triad] (get mappings triad))))
 
-;; Since we assume cells that are off the grid are zeroes, and the far left and far
-;; right calculatoins both require these cells, we make our calculation a bit easier by
-;; simply pretending the previous row has two extra 0s on either side
+;; Since we assume cells that are off the grid are zeroes, and the far left and
+;; far right calculatoins both require these cells, we make our calculation a
+;; bit easier by simply pretending the previous row has two extra 0s on either
+;; side
 (defn bookend
   "Pads a seq with a given value on both sides."
   [x v]
@@ -107,21 +118,20 @@
   "Returns a lazy-seq of future states for a given rule-fn and state"
   [rule-fn state]
   (let [new-state (simulate rule-fn state)]
-    ;; This is an infinitely recursive lazy sequence! Notice how we start
-    ;; by considing (prepending) to a new-state onto the head of a not-yet extant
-    ;; lazy sequence. 
-    ;; You'll notice that the lazy sequence is declared with a
-    ;; body that will recurse from the present state, passing the current state into
-    ;; itself. Lazy sequences such as this are inherently tail-recursive, so they won't
-    ;; blow the stack.
+    ;; This is an infinitely recursive lazy sequence! Notice how we start by
+    ;; considing (prepending) to a new-state onto the head of a not-yet extant
+    ;; lazy sequence. You'll notice that the lazy sequence is declared with a
+    ;; body that will recurse from the present state, passing the current state
+    ;; into itself. Lazy sequences such as this are inherently tail-recursive,
+    ;; so they won't blow the stack.
     (cons new-state (lazy-seq (simulation rule-fn new-state)))))
 
 (defn draw-buffer
   "Redraw what's on screen given a buffer of cell data at a given scale"
   [buffer scale]
-  ;; We use letfn here because we want both of these functions to
-  ;; have access to the variables `buffer` and `scale`. Closing over them
-  ;; here rather than defining them separately is simply a stylistic choice.
+  ;; We use letfn here because we want both of these functions to have access to
+  ;; the variables `buffer` and `scale`. Closing over them here rather than
+  ;; defining them separately is simply a stylistic choice.
   ;;
   ;; We use two nested `map-index` calls to iterated over the canvas row by row,
   ;; cell by cell, rendering each to the UI
@@ -145,13 +155,13 @@
         ;; Our initial state is a single row of random 0s and 1s
         initial (repeatedly height #(rand-int 2))
         sim (simulation (rule rule-num) initial)
-        ;; We use partition as a sliding wintdow here. Since sim is
-        ;; an infinite lazy sequence of future rows we use the 3-arity
-        ;; version of partition here to create a 2D view of the visible range
-        ;; of results. Since this is the 3-arity version of partition, with 1
-        ;; specified as the second parameter, each time we grab the next item from
-        ;; the sim sequence we wind up with the same 2D view as before, but shifted ahead
-        ;; one row. This is how the simulation scrolls down!
+        ;; We use partition as a sliding wintdow here. Since sim is an infinite
+        ;; lazy sequence of future rows we use the 3-arity version of partition
+        ;; here to create a 2D view of the visible range of results. Since this
+        ;; is the 3-arity version of partition, with 1 specified as the second
+        ;; parameter, each time we grab the next item from the sim sequence we
+        ;; wind up with the same 2D view as before, but shifted ahead one row.
+        ;; This is how the simulation scrolls down!
         time-slices (atom (partition height 1 sim))]
     (println "Rule " rule-num " mappings:")
     (pprint (rule-mappings rule-num))
@@ -159,18 +169,20 @@
     (qc/defsketch automata
       :title (str "Rule " rule-num)
       :setup setup
-      :draw (fn drawfn [] ;; Named anonymous functions are easier to stacktrace
-              ;; Lazy sequences can also re-integrate into a more imperitive style
+      :draw (fn drawfn []
+              ;; Named anonymous functions are easier to stacktrace Lazy
+              ;; sequences can also re-integrate into a more imperitive style
               ;; What follows below is convenient, but not quite functional.
-              ;; Since the :draw callback is inherently not recursive I went with a
-              ;; more imperitive approach here. We use an atom to maintain the current position
-              ;; within our infinite sequence. This could also have been archieved with a
-              ;; tail recursive loop and not-utilizing the draw callback, but that's left
-              ;; as an excercise for the reader.
+              ;; Since the :draw callback is inherently not recursive I went
+              ;; with a more imperitive approach here. We use an atom to
+              ;; maintain the current position within our infinite sequence.
+              ;; This could also have been archieved with a tail recursive loop
+              ;; and not-utilizing the draw callback, but that's left as an
+              ;; excercise for the reader.
               (draw-buffer (first @time-slices) scale)
               (swap! time-slices (fn [_] (rest @time-slices))))
       :size [(* scale width) (* scale height)])))
 
 (defn -main [rule-num & args]
   (run-rule (Integer/valueOf rule-num)
-            {:width 100 :height 100 :scale 4}))
+    {:width 100 :height 100 :scale 4}))

--- a/src/quil_sketches/gen_art/30_random_clicked_circles.clj
+++ b/src/quil_sketches/gen_art/30_random_clicked_circles.clj
@@ -34,11 +34,11 @@
 ;;   }
 ;; }
 
-(def num 10)
+(def num-circles 10)
 
 (defn draw-circles []
   (dorun
-   (for [i (range 0 num)]
+   (for [i (range 0 num-circles)]
      (let [x      (random (width))
            y      (random (height))
            radius (+ (random 100) 10)]

--- a/src/quil_sketches/gen_art/31_oo_circles.clj
+++ b/src/quil_sketches/gen_art/31_oo_circles.clj
@@ -77,21 +77,20 @@
 ;;   }
 ;; }
 
-(def num 10)
+(def num-circles 10)
 
 (defn mk-circle []
   {:x        (random (width))
    :y        (random (height))
    :radius   (+ 10 (random 100))
    :line-col (color (random 255) (random 255) (random 255))
-   :fill-col (color (random 255) (random 255) (random 255))
-   :alph     (random 255)
+   :fill-col [(random 255) (random 255) (random 255) (random 255)]
    :xmove    (- (random 10) 5)
    :ymove    (- (random 10) 5)})
 
 (defn add-circles
   [circles*]
-  (dotimes [_ num]
+  (dotimes [_ num-circles]
     (let [c (mk-circle)]
       (swap! circles* conj c))))
 
@@ -103,7 +102,7 @@
   (background 255)
   (smooth)
   (stroke-weight 1)
-  (fill-int 150 50)
+  (fill 150 50)
   (let [circles* (atom [])]
     (add-circles circles*)
     (set-state! :circles circles*)))
@@ -126,9 +125,9 @@
 (defn draw-circle
   [{:keys [x y radius line-col fill-col alph]}]
   (no-stroke)
-  (fill-int fill-col alph)
+  (apply fill fill-col)
   (ellipse x y (* 2 radius) (* 2 radius))
-  (stroke-int line-col 150)
+  (stroke line-col 150)
   (no-fill)
   (ellipse x y 10 10))
 

--- a/src/quil_sketches/graphics.clj
+++ b/src/quil_sketches/graphics.clj
@@ -3,12 +3,12 @@
             [quil.helpers.drawing :refer [line-join-points]]
             [quil.helpers.seqs :refer [range-incl steps]]))
 
-;; Example of using graphics via create-graphics and with-graphics.
-;; On each iteration 1 spiral will be drawn on graphics and then we tile all screen using this graphics.
-;; Graphics created in setup funcion and stored in state.
-;; Spiral is drawn by draw-spiral function that uses standard draw functions.
-;; If draw-spiral function invoked inside 'with-graphics' macro then spiral will be drawn on given graphics,
-;; otherwise spiral is drawon on applet.
+;; Example of using graphics via create-graphics and with-graphics. On each
+;; iteration 1 spiral will be drawn on graphics and then we tile all screen
+;; using this graphics. Graphics created in setup funcion and stored in state.
+;; Spiral is drawn by draw-spiral function that uses standard draw functions. If
+;; draw-spiral function invoked inside 'with-graphics' macro then spiral will be
+;; drawn on given graphics, otherwise spiral is drawon on applet.
 
 (def spiral-size 100)
 
@@ -17,7 +17,8 @@
 
 
 (defn draw-spiral
-  "Draws spiral on current surface: on applet or on graphics if inside with-graphics macro."
+  "Draws spiral on current surface: on applet or on graphics if inside
+  with-graphics macro."
   []
   (with-translation [cent-x cent-y]
     (with-rotation [(/ (frame-count) -5 Math/PI)]
@@ -53,9 +54,9 @@
       (image gr x y))))
 
 (defsketch graphics
-	  :title "Graphics"
-	  :setup setup
-          :draw draw
-          :size [500 500])
+  :title "Graphics"
+  :setup setup
+  :draw draw
+  :size [500 500])
 
 (defn -main [& args])

--- a/src/quil_sketches/key_mover.clj
+++ b/src/quil_sketches/key_mover.clj
@@ -2,12 +2,11 @@
   (:require [quil.core :refer :all])
   (:import java.awt.event.KeyEvent))
 
-(def params {
-	:screen-dimensions [400 400]
-	:background-colour 0
-	:blob-colour 255
-  :blob-radius 10
-  :screen-bounds [0 380]})
+(def params {:screen-dimensions [400 400]
+             :background-colour 0
+             :blob-colour 255
+             :blob-radius 10
+             :screen-bounds [0 380]})
 
 (def blob-location (atom [190 190]))
 
@@ -15,14 +14,14 @@
   ([bounds position] (normalise bounds bounds position))
 
   ([x-bounds y-bounds position]
-  (let [[min-x max-x] x-bounds
-        [min-y max-y] y-bounds
-        [x y] position
-        bound (fn [a-min a-max value]
-                (max a-min (min a-max value)))
-        new-x (bound min-x max-x x)
-        new-y (bound min-y max-y y)]
-       (vector new-x new-y))))
+   (let [[min-x max-x] x-bounds
+         [min-y max-y] y-bounds
+         [x y] position
+         bound (fn [a-min a-max value]
+                 (max a-min (min a-max value)))
+         new-x (bound min-x max-x x)
+         new-y (bound min-y max-y y)]
+     (vector new-x new-y))))
 
 (defn setup []
   (smooth)
@@ -32,27 +31,27 @@
 (defn draw
   []
   (let [blob-size (* 2 (params :blob-radius))
-    [bx by] @blob-location]
-  (background-float (params :background-colour))
-  (fill (params :blob-colour))
-  (rect bx by blob-size blob-size)
-  (text "Use WASD and arrow keys to move" 10 390)))
+        [bx by] @blob-location]
+    (background (params :background-colour))
+    (fill (params :blob-colour))
+    (rect bx by blob-size blob-size)
+    (text "Use WASD and arrow keys to move" 10 390)))
 
 (def valid-keys {
-  KeyEvent/VK_UP :up
-  KeyEvent/VK_DOWN :down
-  KeyEvent/VK_LEFT :left
-  KeyEvent/VK_RIGHT :right
-  \w :up
-  \s :down
-  \a :left
-  \d :right})
+                  KeyEvent/VK_UP :up
+                  KeyEvent/VK_DOWN :down
+                  KeyEvent/VK_LEFT :left
+                  KeyEvent/VK_RIGHT :right
+                  \w :up
+                  \s :down
+                  \a :left
+                  \d :right})
 
 (def moves {:up [0 -10]
-  :down [0 10]
-  :left [-10 0]
-  :right [10 0]
-  :still [0 0]})
+            :down [0 10]
+            :left [-10 0]
+            :right [10 0]
+            :still [0 0]})
 
 (defn charcode-to-keyword [c] (->> c str keyword))
 
@@ -61,9 +60,9 @@
 
 (defn key-press []
   (let [raw-key (raw-key)
-    the-key-code (key-code)
-    the-key-pressed (if (= processing.core.PConstants/CODED (int raw-key)) the-key-code raw-key)
-    move (moves (get valid-keys the-key-pressed :still))]
+        the-key-code (key-code)
+        the-key-pressed (if (= processing.core.PConstants/CODED (int raw-key)) the-key-code raw-key)
+        move (moves (get valid-keys the-key-pressed :still))]
     (swap! blob-location (partial change-location move))
     (swap! blob-location (partial normalise (params :screen-bounds)))
     (redraw)))

--- a/src/quil_sketches/key_mover.clj
+++ b/src/quil_sketches/key_mover.clj
@@ -30,22 +30,21 @@
 
 (defn draw
   []
-  (let [blob-size (* 2 (params :blob-radius))
-        [bx by] @blob-location]
+  (let [blob-size (* 2 (params :blob-radius))]
+       [bx by] @blob-location
     (background (params :background-colour))
     (fill (params :blob-colour))
     (rect bx by blob-size blob-size)
     (text "Use WASD and arrow keys to move" 10 390)))
 
-(def valid-keys {
-                  KeyEvent/VK_UP :up
-                  KeyEvent/VK_DOWN :down
-                  KeyEvent/VK_LEFT :left
-                  KeyEvent/VK_RIGHT :right
-                  \w :up
-                  \s :down
-                  \a :left
-                  \d :right})
+(def valid-keys {KeyEvent/VK_UP :up
+                 KeyEvent/VK_DOWN :down
+                 KeyEvent/VK_LEFT :left
+                 KeyEvent/VK_RIGHT :right
+                 \w :up
+                 \s :down
+                 \a :left
+                 \d :right})
 
 (def moves {:up [0 -10]
             :down [0 10]

--- a/src/quil_sketches/mouse.clj
+++ b/src/quil_sketches/mouse.clj
@@ -8,11 +8,11 @@
 
 (defn draw
   []
-  (background-float 125)
+  (background 125)
   (stroke-weight 20)
-  (stroke-float 10)
-  (let [[x y] @(state :mouse-position)]
-    (point x y)))
+  (with-stroke 10
+    (let [[x y] @(state :mouse-position)]
+      (point x y))))
 
 (defn mouse-moved []
   (let [x (mouse-x)  y (mouse-y)]


### PR DESCRIPTION
This is one of my first commits to anything Clojure, so please point out anything that I can improve.

This PR covers:

- bumping `quil` dependency up to `3.0`.
- going example-by-example, and making sure they can still be run with no visual regressions.
- fixes to all functions that needed to be changed, e.g. calling `background` instead of `background-float`.
- miscellaneous whitespace fixes, as there were tabs mixed in with spaces.